### PR TITLE
Copy over updates from Yuri (PR #244)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shubox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shubox javascript SDK",
   "author": "team@shubox.io",
   "license": "MIT",

--- a/src/shubox/webcam.ts
+++ b/src/shubox/webcam.ts
@@ -18,6 +18,7 @@ export interface IWebcamOptions {
   audioInput?: string;
   videoInput?: string;
   timeLimit?: number;
+  portraitMode?: boolean;
   cameraStarted?: (webcam: Webcam) => void;
   cameraStopped?: (webcam: Webcam) => void;
   photoTaken?: (webcam: Webcam, file: Blob) => void;

--- a/src/shubox/webcam/photo_events.ts
+++ b/src/shubox/webcam/photo_events.ts
@@ -21,8 +21,8 @@ export class PhotoEvents {
       audio: false,
       video: {
         ... {
-          height: this.webcam.element.offsetHeight,
-          width: this.webcam.element.offsetWidth,
+          height: this.webcam.webcamOptions.portraitMode ? this.webcam.element.offsetWidth : this.webcam.element.offsetHeight,
+          width: this.webcam.webcamOptions.portraitMode ? this.webcam.element.offsetHeight : this.webcam.element.offsetWidth
         },
         ...constraints.video,
       },

--- a/src/shubox/webcam/video_dom.ts
+++ b/src/shubox/webcam/video_dom.ts
@@ -25,8 +25,15 @@ export class VideoDom {
     if (this.initialized) { return; }
     this.webcam.element.innerHTML = this.options.videoTemplate || "";
     this.video = this.findOrCreate("video") as HTMLVideoElement;
-    this.video.width = this.webcam.element.offsetWidth;
-    this.video.height = this.webcam.element.offsetHeight;
+
+    this.video.width = this.webcam.webcamOptions.portraitMode ?
+      this.webcam.element.offsetWidth :
+      this.webcam.element.offsetHeight;
+
+    this.video.height = this.webcam.webcamOptions.portraitMode ?
+      this.webcam.element.offsetHeight :
+      this.webcam.element.offsetWidth;
+
     this.initialized = true;
   }
 

--- a/src/shubox/webcam/video_events.ts
+++ b/src/shubox/webcam/video_events.ts
@@ -27,8 +27,8 @@ export class VideoEvents {
       },
       video: {
         ... {
-          height: this.webcam.element.offsetHeight,
-          width: this.webcam.element.offsetWidth,
+          height: this.webcam.webcamOptions.portraitMode ? this.webcam.element.offsetWidth : this.webcam.element.offsetHeight,
+          width: this.webcam.webcamOptions.portraitMode ? this.webcam.element.offsetHeight : this.webcam.element.offsetWidth
         },
         ...constraints.video,
       },


### PR DESCRIPTION
With the complete overhaul of this repo the PR that had been opened previously
was best to be copied over into its own commit and PR.

Shout out to @yuricampolongo for all the work and the outstanding PR description
and commit.

Original PR
===========

https://github.com/shuboxio/shubox.js/pull/244

:point_down: Take it away, Yuri! :point_down:

Goal
====

To have a way to record video in full-screen mode, using Android and iOS. We don't want to open the native
video full-screen mode because we lose access to our custom buttons and texts.

The problem
===========

When getting the navigator.mediaDevices in the script, we don't have a way to define the *width* and
*height* properties. Today the script calculates it automatically based on the container of the video.

    {height:  t.webcam.element.offsetWidth, width:  t.webcam.element.offsetHeight }

The problem is: for mobile if we do that, the video screen will always use the landscape mode, but it would be
nice to record in portrait mode as well

![image](https://user-images.githubusercontent.com/4220126/164063998-bc6aa177-f6da-4094-b922-d945aeab403e.png)

I found some online references about how to make the webcam video to work using full-screen, and we need
to change 2 things:

* Add the attribute playsinline in the video tag, which it is possible to do today using the videoTemplate
property in the webcam object.
* Change how the height and width of the mediaDevice is initialized. If we are In portrait mode, we
need to change both to:

    { width: screen.height, height: screen.width }

In this case the width will be the height of the screen, and the height will be the width.

After changing this, I achieved the goal to record the video in full screen mode

<hr>

So for this PR, I just added a new attribute in the webcam object called: portraitMode, which will change the height and width when loading the media device
